### PR TITLE
add `savingsplans:DescribeSavingsPlans`

### DIFF
--- a/Optima/cloudformation-template/FlexeraCloudCostAccessRole.template
+++ b/Optima/cloudformation-template/FlexeraCloudCostAccessRole.template
@@ -107,7 +107,8 @@ Mappings:
         - "ce:GetSavingsPlansUtilization"
         - "ce:GetReservationPurchaseRecommendation"
         - "ce:GetSavingsPlansPurchaseRecommendation"
-                
+        - "savingsplans:DescribeSavingsPlans"
+
       bucket:
         - "s3:ListBucket"
         - "s3:GetBucketLocation"


### PR DESCRIPTION
Required for AWS Savings Plan inventory/utilization views in Flexera